### PR TITLE
Allow for user-specified minimum region length

### DIFF
--- a/bin/filter_spades_contigs_weigthed.pl
+++ b/bin/filter_spades_contigs_weigthed.pl
@@ -1,5 +1,6 @@
-#!/usr/bin/env perl -w
+#!/usr/bin/env perl
 use strict;
+use warnings;
 
 my $total_length;
 my $accumulated_coverage;

--- a/bin/orientate_plastome.pl
+++ b/bin/orientate_plastome.pl
@@ -1,5 +1,6 @@
-#!/usr/bin/perl -w
+#!/usr/bin/env perl
 use strict;
+use warnings;
 my $lsc;
 my $irb;
 my $ssc;

--- a/bin/orientate_plastome_v.2.0.pl
+++ b/bin/orientate_plastome_v.2.0.pl
@@ -1,5 +1,6 @@
-#!/usr/bin/perl -w
+#!/usr/bin/env perl
 use strict;
+use warnings;
 my $lsc;
 my $irb;
 my $ssc;

--- a/bin/sequence_based_ir_id.pl
+++ b/bin/sequence_based_ir_id.pl
@@ -11,6 +11,9 @@ my $name              = shift // die 'name (second command-line argument) requir
 my $ARGV_2            = shift // die 'third command-line argument required'; # What is a good name for this?
 my $min_region_legnth = shift // $DEFAULT_MIN_REGION_LENGTH;
 
+# Throw error if unknown argument used
+shift() && die 'Unexpected fifth argument not supported';
+
 my $sequence;
 my $sid;
 

--- a/bin/sequence_based_ir_id.pl
+++ b/bin/sequence_based_ir_id.pl
@@ -6,10 +6,10 @@ use v5.10; # Minimum perl providing defined-or "//", which allows defaults to be
 my $DEFAULT_MIN_REGION_LENGTH = 10000;
 
 # Get commandline arguments
-my $current_afin      = shift // die 'current_afin (first command-line argument) required';
-my $name              = shift // die 'name (second command-line argument) required';
-my $ARGV_2            = shift // die 'third command-line argument required'; # What is a good name for this?
-my $min_region_legnth = shift // $DEFAULT_MIN_REGION_LENGTH;
+my $current_afin        = shift // die 'current_afin (first command-line argument) required';
+my $name                = shift // die 'name (second command-line argument) required';
+my $sc_region_to_split_on = shift // die 'sc_region_to_split_on (third command-line argument) required'; 
+my $min_region_legnth   = shift // $DEFAULT_MIN_REGION_LENGTH;
 
 # Throw error if unknown argument used
 shift() && die 'Unexpected fifth argument not supported';
@@ -97,12 +97,14 @@ for my $start (sort {$a<=>$b} keys %regions){
 }
 my $ssc=0;
 for my $start (sort {$a<=>$b} keys %regions){
-        for my $end (keys %{$regions{$start}}){
+	for my $end (keys %{$regions{$start}}){
 		if($regions{$start}{$end} eq "sc"){
 			$ssc++;
-		}
-		if(($ssc == $ARGV_2)  && $regions{$start}{$end} eq "sc"){
-			delete $regions{$start};
+
+			# Remove specified region
+			if($ssc == $sc_region_to_split_on) {
+				delete $regions{$start};
+			}
 		}
 	}
 }
@@ -134,7 +136,7 @@ for my $start (sort {$a<=>$b} keys %regions){
 
 $final_regions{$final_start}{$final_end}=$final_regionid;
 
-open my $out, ">", $name . "_regions_split" . $ARGV_2 . ".fsa";
+open my $out, ">", $name . "_regions_split" . $sc_region_to_split_on . ".fsa";
 for my $start (sort {$a<=>$b} keys %final_regions){
         for my $end (keys %{$final_regions{$start}}){
                 if($end-$start < $min_region_legnth){

--- a/bin/sequence_based_ir_id.pl
+++ b/bin/sequence_based_ir_id.pl
@@ -1,8 +1,20 @@
-#!/usr/bin/perl -w
+#!/usr/bin/perl
 use strict;
+use warnings;
+use v5.10; # Minimum perl providing defined-or "//", which allows defaults to be zero (unlike regular "||")
+
+my $DEFAULT_MIN_REGION_LENGTH = 10000;
+
+# Get commandline arguments
+my $current_afin      = shift // die 'current_afin (first command-line argument) required';
+my $name              = shift // die 'name (second command-line argument) required';
+my $ARGV_2            = shift // die 'third command-line argument required'; # What is a good name for this?
+my $min_region_legnth = shift // $DEFAULT_MIN_REGION_LENGTH;
+
 my $sequence;
 my $sid;
-open my $file, "<", $ARGV[0];
+
+open my $file, "<", $current_afin;
 while(<$file>){
 	chomp;
 	if(/>/){
@@ -86,7 +98,7 @@ for my $start (sort {$a<=>$b} keys %regions){
 		if($regions{$start}{$end} eq "sc"){
 			$ssc++;
 		}
-		if(($ssc == $ARGV[2])  && $regions{$start}{$end} eq "sc"){
+		if(($ssc == $ARGV_2)  && $regions{$start}{$end} eq "sc"){
 			delete $regions{$start};
 		}
 	}
@@ -119,10 +131,10 @@ for my $start (sort {$a<=>$b} keys %regions){
 
 $final_regions{$final_start}{$final_end}=$final_regionid;
 
-open my $out, ">", $ARGV[1] . "_regions_split" . $ARGV[2] . ".fsa";
+open my $out, ">", $name . "_regions_split" . $ARGV_2 . ".fsa";
 for my $start (sort {$a<=>$b} keys %final_regions){
         for my $end (keys %{$final_regions{$start}}){
-                if($end-$start < 10000){
+                if($end-$start < $min_region_legnth){
                         next;
                 }
                 my $tempseq = substr($sequence,$start,($end-$start+1));

--- a/bin/sequence_based_ir_id.pl
+++ b/bin/sequence_based_ir_id.pl
@@ -6,10 +6,10 @@ use v5.10; # Minimum perl providing defined-or "//", which allows defaults to be
 my $DEFAULT_MIN_REGION_LENGTH = 10000;
 
 # Get commandline arguments
-my $current_afin        = shift // die 'current_afin (first command-line argument) required';
-my $name                = shift // die 'name (second command-line argument) required';
+my $current_afin          = shift // die 'current_afin (first command-line argument) required';
+my $name                  = shift // die 'name (second command-line argument) required';
 my $sc_region_to_split_on = shift // die 'sc_region_to_split_on (third command-line argument) required'; 
-my $min_region_legnth   = shift // $DEFAULT_MIN_REGION_LENGTH;
+my $min_region_legnth     = shift // $DEFAULT_MIN_REGION_LENGTH;
 
 # Throw error if unknown argument used
 shift() && die 'Unexpected fifth argument not supported';

--- a/fast-plast.pl
+++ b/fast-plast.pl
@@ -48,8 +48,9 @@ my $user_bowtie;
 my $clean;
 my $subsample;
 my $cov_only;
+my $min_region_length = 10000;
 my $skip;
-GetOptions('help|?' => \$help,'version' => \$version, "1=s" => \$paired_end1, "2=s" => \$paired_end2, "single=s" => \$single_end, "bowtie_index=s" => \$bowtie_index, "user_bowtie=s" => \$user_bowtie, "name=s" => \$name, "clean=s" => \$clean, 'coverage_analysis' => \$coverage_check, 'skip=s' => \$skip, 'positional_genes' => \$posgenes, "threads=i" => \$threads, "min_coverage=i" => \$min_coverage, "adapters=s" => \$adapters, "subsample=i" => \$subsample, "only_coverage=s" => \$cov_only)  or pod2usage( { -message => "ERROR: Invalid parameter." } );
+GetOptions('help|?' => \$help,'version' => \$version, "1=s" => \$paired_end1, "2=s" => \$paired_end2, "single=s" => \$single_end, "bowtie_index=s" => \$bowtie_index, "user_bowtie=s" => \$user_bowtie, "name=s" => \$name, "clean=s" => \$clean, 'coverage_analysis' => \$coverage_check, 'skip=s' => \$skip, 'positional_genes' => \$posgenes, "threads=i" => \$threads, "min_coverage=i" => \$min_coverage, "adapters=s" => \$adapters, "subsample=i" => \$subsample, "only_coverage=s" => \$cov_only, "min_region_length=i" => \$min_region_length)  or pod2usage( { -message => "ERROR: Invalid parameter." } );
 
 if($version) {
 	pod2usage( { -verbose => 99, -sections => "VERSION" } );
@@ -1684,7 +1685,7 @@ sub orientate_plastome{
 
         for (my $i = 0; $i <=3; $i++){
 
-        	`perl $FPBIN/sequence_based_ir_id.pl $current_afin $name $i`;
+        	`perl $FPBIN/sequence_based_ir_id.pl $current_afin $name $i $min_region_length`;
         	my $split_fullname= $name ."_regions_split".$i.".fsa";
 
         	`$BLAST/makeblastdb -in $split_fullname -dbtype nucl`;
@@ -2021,6 +2022,7 @@ Advanced options:
 	--user_bowtie		User supplied bowtie2 indices. If this option is used, bowtie_index is ignored.
 	--posgenes		User defined genes for identification of single copy/IR regions and orientation. Useful when major rearrangments are present in user plastomes.
 	--coverage_analysis 	Flag to run the coverage analysis of a final chloroplast assembly.
+	--min_region_length 	Minimum region length (passed on to sequence_based_ir_id.pl)
 
 =head1 DESCRIPTION
 


### PR DESCRIPTION
Minimum region length can be specified to` fast-plast.pl` as the named parameter `--min_region_length` or as the fourth command line argument to `bin/sequence_based_ir_id.pl`.

Also, updated executability of a few more Perl scripts.
`
